### PR TITLE
Support FSCTL_SET_SPARSE IOCTL

### DIFF
--- a/src/fsWin.cpp
+++ b/src/fsWin.cpp
@@ -8,6 +8,7 @@
 #include "setShortName.h"
 #include "getCompressedSize.h"
 #include "setCompression.h"
+#include "setSparse.h"
 
 NAPI_MODULE_INIT() {
 	napi_value o;
@@ -33,6 +34,8 @@ NAPI_MODULE_INIT() {
 	napi_set_named_property(env, o, "getCompressedSizeSync", getCompressedSize::init(env, true));
 	napi_set_named_property(env, o, "setCompression", setCompression::init(env));
 	napi_set_named_property(env, o, "setCompressionSync", setCompression::init(env, true));
+	napi_set_named_property(env, o, "setSparse", setSparse::init(env));
+	napi_set_named_property(env, o, "setSparseSync", setSparse::init(env, true));
 
 	return exports;
 }

--- a/src/setSparse.h
+++ b/src/setSparse.h
@@ -1,0 +1,119 @@
+#pragma once
+#include "common.h"
+
+class setSparse {
+public:
+	static bool func(const wchar_t *path) {
+		bool result = false;
+		HANDLE hnd = CreateFileW(path, FILE_GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ, NULL, OPEN_ALWAYS, 0, NULL);
+		if (hnd != INVALID_HANDLE_VALUE) {
+			DWORD d;
+			if (DeviceIoControl(hnd, FSCTL_SET_SPARSE, NULL, 0, NULL, 0, &d, NULL)) {
+				result = true;
+			}
+			CloseHandle(hnd);
+		}
+		return result;
+	}
+	static napi_value init(napi_env env, bool isSync = false) {
+		napi_value f;
+		napi_create_function(env, NULL, 0, isSync ? sync : async, NULL, &f);
+		return f;
+	}
+private:
+	const struct cbdata {
+		napi_async_work work;
+		napi_ref self;
+		napi_ref cb;
+		wchar_t *path;
+		bool result;
+	};
+	static napi_value sync(napi_env env, napi_callback_info info) {
+		napi_value result;
+		napi_get_new_target(env, info, &result);
+		if (result) {
+			result = NULL;
+			napi_throw_error(env, SYB_EXP_INVAL, SYB_ERR_NOT_A_CONSTRUCTOR);
+		} else {
+			napi_value argv[2];
+			size_t argc = 2;
+			napi_get_cb_info(env, info, &argc, argv, NULL, NULL);
+			if (argc < 1) {
+				napi_throw_error(env, SYB_EXP_INVAL, SYB_ERR_WRONG_ARGUMENTS);
+			} else {
+				size_t str_len;
+				napi_value tmp;
+				napi_coerce_to_string(env, argv[0], &tmp);
+				napi_get_value_string_utf16(env, tmp, NULL, 0, &str_len);
+				str_len += 1;
+				wchar_t *path = (wchar_t*)malloc(sizeof(wchar_t) * str_len);
+				napi_get_value_string_utf16(env, tmp, (char16_t*)path, str_len, NULL);
+				napi_get_boolean(env, func(path), &result);
+				free(path);
+			}
+		}
+		return result;
+	}
+	static napi_value async(napi_env env, napi_callback_info info) {
+		napi_value result;
+		napi_get_new_target(env, info, &result);
+		if (result) {
+			result = NULL;
+			napi_throw_error(env, SYB_EXP_INVAL, SYB_ERR_NOT_A_CONSTRUCTOR);
+		} else {
+			napi_value argv[3], self;
+			size_t argc = 3;
+			napi_get_cb_info(env, info, &argc, argv, &self, NULL);
+			if (argc < 2) {
+				napi_throw_error(env, SYB_EXP_INVAL, SYB_ERR_WRONG_ARGUMENTS);
+			} else {
+				napi_valuetype t;
+				napi_typeof(env, argv[2], &t);
+				if (t == napi_function) {
+					cbdata *data = (cbdata*)malloc(sizeof(cbdata));
+					size_t str_len;
+					napi_value tmp;
+					napi_create_reference(env, argv[2], 1, &data->cb);
+					napi_create_reference(env, self, 1, &data->self);
+					napi_coerce_to_string(env, argv[0], &tmp);
+					napi_get_value_string_utf16(env, tmp, NULL, 0, &str_len);
+					str_len += 1;
+					data->path = (wchar_t*)malloc(sizeof(wchar_t) * str_len);
+					napi_get_value_string_utf16(env, tmp, (char16_t*)data->path, str_len, NULL);
+					napi_create_string_latin1(env, "fswin.setSparse", NAPI_AUTO_LENGTH, &tmp);
+					napi_create_async_work(env, argv[0], tmp, execute, complete, data, &data->work);
+					if (napi_queue_async_work(env, data->work) == napi_ok) {
+						napi_get_boolean(env, true, &result);
+					} else {
+						napi_get_boolean(env, false, &result);
+						napi_delete_reference(env, data->cb);
+						napi_delete_reference(env, data->self);
+						napi_delete_async_work(env, data->work);
+						free(data->path);
+						free(data);
+					}
+				} else {
+					napi_throw_error(env, SYB_EXP_INVAL, SYB_ERR_WRONG_ARGUMENTS);
+				}
+			}
+		}
+		return result;
+	}
+	static void execute(napi_env env, void *data) {
+		cbdata *d = (cbdata*)data;
+		d->result = func(d->path);
+	}
+	static void complete(napi_env env, napi_status status, void *data) {
+		cbdata *d = (cbdata*)data;
+		free(d->path);
+		napi_value cb, self, argv;
+		napi_get_reference_value(env, d->cb, &cb);
+		napi_get_reference_value(env, d->self, &self);
+		napi_get_boolean(env, status == napi_ok && d->result, &argv);
+		napi_call_function(env, self, cb, 1, &argv, NULL);
+		napi_delete_reference(env, d->cb);
+		napi_delete_reference(env, d->self);
+		napi_delete_async_work(env, d->work);
+		free(d);
+	}
+};


### PR DESCRIPTION
This closes #25 

```js
// PS> node-gyp rebuild
var fswin = require('./build/Release/fswin.node');
var file = 'c:\\ten';

const result = fswin.ntfs.setSparseSync(file)
console.log(`setting of ${file} to sparse`, result ? 'succeeded' : 'failed');

const fs = require('fs')
fs.open(file, 'r+', (err, fd) => {
  fs.write(fd, Buffer.from([1]), 0, 1, 0, (err) => {
    if(err) {
      console.log("1")
      return fs.close(fd, () => {})
    }
    fs.write(fd, Buffer.from([1]), 0, 1, 10000000, (err) => {
      if(err) {
        console.log("2")
      }
      return fs.close(fd, () => {})
    })
  })
});

// PS> fsutil sparse queryflag c:\ten
// This file is set as sparse

// right click -> properties
// Size: 9.53 MB (10,000,001 bytes)
// Size on Disk: 128 KB (131,072 bytes)
```

A few talking points.
* I put this under the `fswin.ntfs` namespace because sparse files are only supported on NTFS and UDF
* I didn't allow for toggling off sparse mode, because officially there is no windows API for doing so. Windows expects you to recreate the file, and I don't feel confident implementing that in C++ (or even if I should).
* Toggling this flag, does not tell Windows to go free up space. This flag should be set on file creation, then written to.
* I chose to use `OPEN_ALWAYS` when calling `CreateFileW` but I noticed that precedent from `setCompression` uses `OPEN_EXISTING`. However because this flag setting should be done on file creation, I chose the `OPEN_ALWAYS` mode.
* Attempting to open the file in node with `fs.open(file, 'w')` totally wipes the sparse flag, this is a node thing, and just something to be aware of.

I don't know if setting the sparse flag deserves it's own high level `ntfs.setSparse` function, or if we should instead just make a [`setFileControlCode`](https://docs.microsoft.com/en-us/windows/win32/fileio/file-management-control-codes) to handle all of the available features. I leave that decision up to the project maintainer. But my fork solves my problem.